### PR TITLE
Fix row/column consistency in CubicSplineND gradient propagation

### DIFF
--- a/include/SplineTrajectory.hpp
+++ b/include/SplineTrajectory.hpp
@@ -936,8 +936,9 @@ namespace SplineTrajectory
                 ws_lambda_.row(i + 1) += g_c3 * (h_inv / 6.0);
 
                 VectorType dP = spatial_points_[i + 1] - spatial_points_[i];
-                VectorType term_dC1_dh = -dP * h2_inv - (2.0 * M.row(i) + M.row(i + 1)).transpose() / 6.0;
-                VectorType term_dC3_dh = -(M.row(i + 1) - M.row(i)).transpose() * (h2_inv / 6.0);
+                const RowVectorType dP_row = dP.transpose();
+                const RowVectorType term_dC1_dh = -dP_row * h2_inv - (2.0 * M.row(i) + M.row(i + 1)) / 6.0;
+                const RowVectorType term_dC3_dh = -(M.row(i + 1) - M.row(i)) * (h2_inv / 6.0);
 
                 gradByTimes(i) += g_c1.dot(term_dC1_dh) + g_c3.dot(term_dC3_dh);
             }
@@ -949,21 +950,22 @@ namespace SplineTrajectory
                 const auto &tp = time_powers_[k];
                 double h2_inv = tp.h2_inv;
                 VectorType dP = spatial_points_[k + 1] - spatial_points_[k];
+                const RowVectorType dP_row = dP.transpose();
 
-                VectorType common_term = ws_lambda_.row(k) - ws_lambda_.row(k + 1);
+                const RowVectorType common_term = ws_lambda_.row(k) - ws_lambda_.row(k + 1);
 
-                RowVectorType grad_R_P = (6.0 * tp.h_inv * common_term).transpose();
+                const RowVectorType grad_R_P = 6.0 * tp.h_inv * common_term;
                 add_point_grad(k + 1, grad_R_P);
                 add_point_grad(k, -grad_R_P);
 
-                VectorType grad_R_h = -6.0 * dP * h2_inv;
+                const RowVectorType grad_R_h = -6.0 * dP_row * h2_inv;
                 gradByTimes(k) += common_term.dot(grad_R_h);
 
-                VectorType M_k = M.row(k);
-                VectorType M_k1 = M.row(k + 1);
+                const RowVectorType M_k = M.row(k);
+                const RowVectorType M_k1 = M.row(k + 1);
 
-                VectorType term_k = 2.0 * M_k + M_k1;
-                VectorType term_k1 = M_k + 2.0 * M_k1;
+                const RowVectorType term_k = 2.0 * M_k + M_k1;
+                const RowVectorType term_k1 = M_k + 2.0 * M_k1;
 
                 gradByTimes(k) -= ws_lambda_.row(k).dot(term_k);
                 gradByTimes(k) -= ws_lambda_.row(k + 1).dot(term_k1);


### PR DESCRIPTION
### Motivation
- Prevent hidden row/column dimension mismatches in gradient propagation where values read via `row(...)` were treated as column `VectorType` and relied on implicit transposes. 
- Ensure `dot`, addition/subtraction and scalar multiplications in `CubicSplineND::propagateGradInternal` use explicitly matching shapes to avoid subtle bugs in gradient math. 

### Description
- Normalize the internal gradient math in `propagateGradInternal` by using `RowVectorType` for quantities taken from `row(...)` and for intermediate terms that are combined with those rows. 
- Introduce `dP_row = dP.transpose()` and replace uses of `dP` where a row-vector is expected with `dP_row`. 
- Convert `common_term`, `M_k`, `M_k1`, `term_k`, `term_k1`, `grad_R_P`, `grad_R_h`, `term_dC1_dh`, and `term_dC3_dh` to `RowVectorType` (and mark them `const` where appropriate) so binary ops and `dot` calls use consistent shapes. 
- The change is localized to `include/SplineTrajectory.hpp` in the `CubicSplineND::propagateGradInternal` implementation and keeps the rest of the API and higher-level logic intact. 

### Testing
- Attempted a full build with `cmake -S . -B build && cmake --build build -j2`, but configuration failed because the environment lacks the Eigen3 CMake package (`Eigen3Config.cmake` / `eigen3-config.cmake`), so no binary was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eba58bc708332a86fa343686fd294)